### PR TITLE
fix internals.originParser

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -210,8 +210,8 @@ internals.originParser = function (origin, allowOrigins, request) {
     // Split origin in to port and domain
 
     this._origin = origin.split(':');
-    this._originPort = this._origin.length === 2 ? this._origin[1] : null;
-    this._originParts = this._origin[0].split('.');
+    this._originPort = this._origin.length === 3 ? this._origin[2] : null;
+    this._originParts = this._origin[1].split('.');
 
     // Iterate through allowed origins list and check origin header matches
 
@@ -221,8 +221,8 @@ internals.originParser = function (origin, allowOrigins, request) {
         }
 
         this._originAllow = allowOrigins[i].split(':');
-        this._originAllowPort = this._originAllow.length === 2 ? this._originAllow[1] : null;
-        this._originAllowParts = this._originAllow[0].split('.');
+        this._originAllowPort = this._originAllow.length === 3 ? this._originAllow[2] : null;
+        this._originAllowParts = this._originAllow[1].split('.');
 
         if ((this._originPort && !this._originAllowPort) || (!this._originPort && this._originAllowPort) || (this._originAllowPort !== '*' && this._originPort !== this._originAllowPort)) {
             this._match = false;


### PR DESCRIPTION
### Test case before fix
```javascript
HOST => 0.0.0.0:9000
REQUEST_HOST => 127.0.0.1:9000
HOST === REQUEST_HOST => false

ORIGIN => "http://wega.demo:8080"
ALLOWS_ORIGINS => ["http://127.0.0.1:8080"]

this._origin  = origin.split(':') => ["http","//wega.demo","8080"]
this._originPort = this._origin.length === 2 ? this._origin[1] : null => null
this._originParts = this._origin[0].split('.') => ["http"]

allowOrigins[i] => http://127.0.0.1:8080

this._originAllow = allowOrigins[i].split(':') => ["http","//127.0.0.1","8080"]
this._originAllowPort = this._originAllow.length === 2 ? this._originAllow[1] : null => null
this._originAllowParts = this._originAllow[0].split('.') => ["http"]

this._originAllowParts[j] => http
this._originParts[j] => http

this._originAllowParts[j] === '*' => false
this._originAllowParts[j] === this._originParts[j] => true

MATCH => true

RETURN MATCH => true
```

We can see that we have differences between `origin` and `allowOrigins` but method returns `true` - `failed`

### Test case after fix
```javascript
HOST => 0.0.0.0:9000
REQUEST_HOST => 127.0.0.1:9000
HOST === REQUEST_HOST => false

ORIGIN => "http://wega.demo:8080"
ALLOWS_ORIGINS => ["http://127.0.0.1:8080"]

this._origin  = origin.split(':') => ["http","//wega.demo","8080"]
this._originPort = this._origin.length === 3 ? this._origin[2] : null => "8080"
this._originParts = this._origin[1].split('.') => ["//wega","demo"]

allowOrigins[i] => http://127.0.0.1:8080

this._originAllow = allowOrigins[i].split(':') => ["http","//127.0.0.1","8080"]
this._originAllowPort = this._originAllow.length === 3 ? this._originAllow[2] : null => "8080"
this._originAllowParts = this._originAllow[1].split('.') => ["//127","0","0","1"]

this._originAllowParts[j] => //127
this._originParts[j] => //wega

this._originAllowParts[j] === '*' => false
this._originAllowParts[j] === this._originParts[j] => false

MATCH => false

END METHOD - RETURN MATCH => false
```

With the `fix`, result is correct because method returns `false` - `correct`

Thanks to add this fix in your plugin ASAP because I think is a very important issue.

Best regards.